### PR TITLE
OSX Compile Fix

### DIFF
--- a/src/qt/multisenddialog.cpp
+++ b/src/qt/multisenddialog.cpp
@@ -7,6 +7,7 @@
 #include <QLineEdit>
 #include <QMessageBox>
 #include <boost/lexical_cast.hpp>
+#include <QStyle>
 
 using namespace std;
 using namespace boost;


### PR DESCRIPTION
Fixes  member access into incomplete type 'QStyle'    ui->message->style()->polish(ui->message);

![image](https://user-images.githubusercontent.com/5182697/51798387-15e0fa00-21df-11e9-8086-d8face9e34a9.png)

![image](https://user-images.githubusercontent.com/5182697/51798406-77a16400-21df-11e9-9fb0-9aa24f85f92e.png)
